### PR TITLE
Disable RL workflow

### DIFF
--- a/.github/workflows/nightly-RL.yml.disabled
+++ b/.github/workflows/nightly-RL.yml.disabled
@@ -1,3 +1,5 @@
+# IMPORTANT: This workflow was disabled as release no longer matches selectors used to find elelments
+
 name: Nightly Test run (Jahia RL)
 
 on:


### PR DESCRIPTION
Disable RL workflow as selectors no longer available in release version of Jahia