### PR TITLE
test: fix provisioning URL

### DIFF
--- a/tests/provisioning-manifest-snapshot.yml
+++ b/tests/provisioning-manifest-snapshot.yml
@@ -1,7 +1,7 @@
 - addMavenRepository: 'https://store.jahia.com/nexus/content/repositories/jahia-public-app-store@id=JahiaStore'
 - addMavenRepository: 'https://devtools.jahia.com/nexus/content/groups/public/@snapshots@noreleases@id=JahiaSnapshot'
 
-- addMavenRepository: 'https://devtools.jahia.com/nexus/content/groups/internal@id=jahia-internal@snapshots'
+- addMavenRepository: 'https://devtools.jahia.com/nexus/content/groups/internal/@id=jahia-internal@snapshots'
   username: ${env:NEXUS_USERNAME}
   password: ${env:NEXUS_PASSWORD}
 
@@ -36,7 +36,7 @@
   do:
     - uninstallBundle: 'mvn:org.jahia.modules/content-editor/3.6.0'
 
-- installBundle: 
+- installBundle:
   - 'mvn:org.jahia.modules/jcontent'
   - 'mvn:org.jahia.modules/site-settings-seo'
   - 'mvn:org.jahia.modules/copy-to-other-languages'


### PR DESCRIPTION
## Description

After a change in httpcomponent here https://github.com/apache/httpcomponents-client/pull/624/files#diff-db78ac5f9e089dd5dfda623225323b303e24aa39bdbab1105bcb806ca5958760R65
We need to add an extra / in the URL for provisioning used on 8.2.

## Tests

The following are included in this PR
- [ ] Unit Tests (Most changes _should_ have unit tests)
- [ ] Integration Tests

## Checklist

<!-- 
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics. 
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

I have considered the following implications of my change: 

- [ ] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [ ] Performance
- [ ] Migration
- [ ] Code maintainability

## Documentation

<!-- 
Indicate if you have been writing documentation has part of this change.
-->

- [ ] Inline documentation
- [ ] Internal Documentation (wiki)
- [ ] User-facing Documentation
