### PR TITLE
ci: fixed incorrect cypress report filename

### DIFF
--- a/tests/package.json
+++ b/tests/package.json
@@ -41,7 +41,7 @@
     "e2e:debug": "cypress open",
     "lint": "eslint --ext .ts .",
     "lint:fix": "eslint --ext .ts --fix .",
-    "report:merge": "mochawesome-merge results/reports/mochawesome*.json > results/reports/report.json && rm results/reports/mochawesome*.json",
+    "report:merge": "mochawesome-merge results/reports/cypress*.json > results/reports/report.json && rm results/reports/mochawesome*.json",
     "report:html": "marge results/reports/report.json --reportDir results --assetsDir results/assets",
     "build": "tsc -p ./lib-tsconfig.json",
     "publish-tests": "yarn version --prerelease --preid=tests && git push --follow-tags && npm publish --access public"


### PR DESCRIPTION
The previous setup was causing the reporter to not manage to report on test status due to incorrect filename.